### PR TITLE
Removed a literal containing hardcoded package info

### DIFF
--- a/DataCapture1/app/src/main/java/com/zebra/datacapture1/MainActivity.java
+++ b/DataCapture1/app/src/main/java/com/zebra/datacapture1/MainActivity.java
@@ -180,7 +180,7 @@ public class MainActivity extends AppCompatActivity {
         intentConfig.putString("RESET_CONFIG", "true");
         Bundle intentProps = new Bundle();
         intentProps.putString("intent_output_enabled", "true");
-        intentProps.putString("intent_action", "com.zebra.datacapture1.ACTION");
+        intentProps.putString("intent_action", getResources().getString(R.string.activity_intent_filter_action));
         intentProps.putString("intent_delivery", "2");
         intentConfig.putBundle("PARAM_LIST", intentProps);
         profileConfig.putBundle("PLUGIN_CONFIG", intentConfig);


### PR DESCRIPTION
"com.zebra.datacapture1.ACTION" is a project specific literal and since it is available in the string.xml file. I'd propose to use that.